### PR TITLE
Fix error in call to map() function

### DIFF
--- a/glucometerutils/drivers/otultra2.py
+++ b/glucometerutils/drivers/otultra2.py
@@ -115,8 +115,8 @@ def _parse_datetime(response):
     raise exceptions.InvalidResponse(response)
 
   date, time = match.groups()
-  month, day, year = map(date.split('/'), int)
-  hour, minute, second = map(time.split(':'), int)
+  month, day, year = map(int, date.split('/'))
+  hour, minute, second = map(int, time.split(':'))
 
   # Yes, OneTouch2's firmware is not Y2K safe.
   return datetime.datetime(2000 + year, month, day, hour, minute, second)


### PR DESCRIPTION
In the otultra2 driver, there is an error in the call to the map() function where the order of the arguments is reversed. This causes an error when running glucometerutils. This PR has the fix.