### PR TITLE
Open OneTouch Verio devices in readwrite mode by default.

### DIFF
--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -100,7 +100,7 @@ def _convert_timestamp(timestamp):
 class Device(object):
   def __init__(self, device):
     self.device_name_ = device
-    self.scsi_device_ = SCSIDevice(device)
+    self.scsi_device_ = SCSIDevice(device, readwrite=True)
     self.scsi_ = SCSI(self.scsi_device_)
     self.scsi_.blocksize = _REGISTER_SIZE
 


### PR DESCRIPTION
Opening the device with read+write permissions is necessary to send write10 SCSI
commands. The error message I was receiving was "SG_IO ioctl error; Operation
not permitted" when running as non-root.

http://sg.danny.cz/sg/sg_io.html describes SCSI permissions in greater depth and
helped illuminate the nature of the permissions problem.