### PR TITLE
Python 2.7 support

### DIFF
--- a/glucometer.py
+++ b/glucometer.py
@@ -65,10 +65,10 @@ def main():
 
   try:
     driver = importlib.import_module('glucometerutils.drivers.' + args.driver)
-  except ImportError:
+  except ImportError as e:
     logging.error(
-      'No driver "%s" found, please check your --driver parameter.',
-      args.driver)
+      'Error importing driver "%s", please check your --driver parameter:\n%s',
+      args.driver, e)
     return 1
 
   # This check needs to happen before we try to initialize the device, as the

--- a/glucometerutils/drivers/fslibre.py
+++ b/glucometerutils/drivers/fslibre.py
@@ -68,10 +68,12 @@ def _parse_record(record, entry_map):
     if not record:
         return {}
 
-    return {
-        key: int(record[idx])
-        for idx, key in entry_map
-    }
+    try:
+        return {
+            key: int(record[idx]) for idx, key in entry_map
+        }
+    except IndexError:
+        return {}
 
 
 def _extract_timestamp(parsed_record):
@@ -145,7 +147,9 @@ def _parse_arresult(record):
             comment_parts.append('Long-acting insulin')
 
     if parsed_record['rapid-acting-flag']:
-        if parsed_record['double-rapid-acting-insulin']:
+        # provide default value, as this record does not always exist
+        # (even if rapid-acting-flag is set)
+        if parsed_record.get('double-rapid-acting-insulin', 0):
             comment_parts.append(
                 'Rapid-acting insulin (%d)' %
                 (parsed_record['double-rapid-acting-insulin']/2))

--- a/glucometerutils/drivers/fsoptium.py
+++ b/glucometerutils/drivers/fsoptium.py
@@ -89,7 +89,7 @@ class Device(serial.SerialDevice):
   DEFAULT_CABLE_ID = '1a61:3420'
 
   def _send_command(self, command):
-    cmd_bytes = bytes('$%s\r\n' % command, 'ascii')
+    cmd_bytes = bytearray('$%s\r\n' % command, 'ascii')
     self.serial_.write(cmd_bytes)
     self.serial_.flush()
 

--- a/glucometerutils/drivers/otultra2.py
+++ b/glucometerutils/drivers/otultra2.py
@@ -94,7 +94,7 @@ def _validate_and_strip_checksum(line):
   try:
     checksum_given = int(checksum_string, 16)
     checksum_calculated = _calculate_checksum(
-      bytes(response, 'ascii'))
+      bytearray(response, 'ascii'))
 
     if checksum_given != checksum_calculated:
       raise exceptions.InvalidChecksum(checksum_given,
@@ -148,7 +148,7 @@ class Device(serial.SerialDevice):
     Args:
       cmd: command and parameters to send (without newline)
     """
-    cmdstring = bytes('\x11\r' + cmd + '\r', 'ascii')
+    cmdstring = bytearray('\x11\r' + cmd + '\r', 'ascii')
     self.serial_.write(cmdstring)
     self.serial_.flush()
 

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -104,7 +104,7 @@ def _encode_message(cmd):
   checksum = _STRUCT_CHECKSUM.pack(lifescan.crc_ccitt(message))
 
   # Pad the message to match the size of the register.
-  return message + checksum + bytes(
+  return message + checksum + bytearray(
     _REGISTER_SIZE - 2 - len(message))
 
 def _convert_timestamp(timestamp):

--- a/glucometerutils/support/freestyle.py
+++ b/glucometerutils/support/freestyle.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Common routines to implement the FreeStyle common protocol.
 
 Protocol documentation available at

--- a/glucometerutils/support/serial.py
+++ b/glucometerutils/support/serial.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Common routines and base driver class for serial-based meters.
 """
 

--- a/test/test_otultra2.py
+++ b/test/test_otultra2.py
@@ -28,14 +28,14 @@ class TestOTUltra2(unittest.TestCase):
         self.device = otultra2.Device('mockdevice')
 
     def _set_return_string(self, string):
-        self.mock_readline.return_value = bytes(string, 'ascii')
+        self.mock_readline.return_value = bytearray(string, 'ascii')
 
     def test_checksum(self):
-        checksum = otultra2._calculate_checksum(bytes('T', 'ascii'))
+        checksum = otultra2._calculate_checksum(bytearray('T', 'ascii'))
         self.assertEqual(0x0054, checksum)
 
         checksum = otultra2._calculate_checksum(
-            bytes('T "SAT","08/03/13","22:12:00   "', 'ascii'))
+            bytearray('T "SAT","08/03/13","22:12:00   "', 'ascii'))
         self.assertEqual(0x0608, checksum)
 
     def test_missing_checksum(self):


### PR DESCRIPTION
As my Ubuntu 14.04 still has Python 2.7 as default, I made a few minor changes to make it run on Python 2.7 as well.
I tested it also on Python 3, so this does not seem to break anything there...