### PR TITLE
Initial support for ketones

### DIFF
--- a/glucometerutils/common.py
+++ b/glucometerutils/common.py
@@ -53,10 +53,10 @@ def convert_glucose_unit(value, from_unit, to_unit=None):
     return round(value * 18.0, 0)
 
 _ReadingBase = collections.namedtuple(
-  '_ReadingBase', ['timestamp', 'value', 'meal', 'comment'])
+  '_ReadingBase', ['timestamp', 'value', 'meal', 'comment','typeofmeasure', 'unit'])
 
 class Reading(_ReadingBase):
-  def __new__(cls, timestamp, value, meal=NO_MEAL, comment=''):
+  def __new__(cls, timestamp, value, meal=NO_MEAL, comment='', typeofmeasure='glucose', unit=UNIT_MGDL):
     """Constructor for the reading object.
 
     Args:
@@ -70,7 +70,7 @@ class Reading(_ReadingBase):
     format.
     """
     return super(Reading, cls).__new__(
-      cls, timestamp=timestamp, value=value, meal=meal, comment=comment)
+      cls, timestamp=timestamp, value=value, meal=meal, comment=comment, typeofmeasure=typeofmeasure, unit=unit)
 
   def get_value_as(self, to_unit):
     """Returns the reading value as the given unit.
@@ -82,8 +82,8 @@ class Reading(_ReadingBase):
 
   def as_csv(self, unit):
     """Returns the reading as a formatted comma-separated value string."""
-    return '"%s","%.2f","%s","%s"' % (
-      self.timestamp, self.get_value_as(unit), self.meal, self.comment)
+    return '"%s","%.2f","%s","%s","%s"' % (
+      self.timestamp, self.get_value_as(unit), self.meal, self.comment, self.typeofmeasure)
 
 
 _MeterInfoBase = collections.namedtuple(

--- a/glucometerutils/common.py
+++ b/glucometerutils/common.py
@@ -87,11 +87,11 @@ class Reading(_ReadingBase):
 
 
 _MeterInfoBase = collections.namedtuple(
-  '_MeterInfoBase', ['model', 'serial_number', 'version_info', 'native_unit'])
+  '_MeterInfoBase', ['model', 'serial_number', 'version_info', 'native_unit', 'ketone_unit'])
 
 class MeterInfo(_MeterInfoBase):
   def __new__(cls, model, serial_number='N/A', version_info=(),
-              native_unit=UNIT_MGDL):
+              native_unit=UNIT_MGDL, ketone_unit=UNIT_MMOLL):
     """Construct a meter information object.
 
     Args:
@@ -99,10 +99,11 @@ class MeterInfo(_MeterInfoBase):
       serial_number: (string) Optional serial number to identify the device.
       version_info: (list(string)) Optional hardware/software version information.
       native_unit: (UNIT_MGDL|UNIT_MMOLL) Native unit of the device for display.
+      ketone_unit: (UNIT_MGDL|UNIT_MMOLL) Ketone unit of the device for display.
     """
     return super(MeterInfo, cls).__new__(
       cls, model=model, serial_number=serial_number, version_info=version_info,
-      native_unit=native_unit)
+      native_unit=native_unit, ketone_unit=ketone_unit)
 
   def __str__(self):
     version_information_string = 'N/A'
@@ -115,6 +116,7 @@ class MeterInfo(_MeterInfoBase):
       Version Information:
           {version_information_string}
       Native Unit: {native_unit}
+      Ketone Unit: {ketone_unit}
       """).format(model=self.model, serial_number=self.serial_number,
                   version_information_string=version_information_string,
-                  native_unit=self.native_unit)
+                  native_unit=self.native_unit, ketone_unit=self.ketone_unit)

--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -31,9 +31,11 @@ from glucometerutils.support import freestyle
 
 
 # The type is a string because it precedes the parsing of the object.
-_TYPE_GLUCOSE_READING = '7'
+_TYPE_READING = { 'Ketone' : '9' , 'Glucose' : '7' }
 
-_NeoReading = collections.namedtuple('_NeoReading', (
+_NeoReading = {
+
+'7': collections.namedtuple('_NeoReading', (
     'type',  # 7 = blood glucose
     'id',
     'month', 'day', 'year',  # year is two-digits
@@ -42,7 +44,21 @@ _NeoReading = collections.namedtuple('_NeoReading', (
     'value',
     'unknown3', 'unknown4', 'unknown5', 'unknown6', 'unknown7',
     'unknown8', 'unknown9', 'unknown10', 'unknown11', 'unknown12',
+)) ,
+
+# Ketones!
+
+'9':  collections.namedtuple('_NeoReading', (
+    'type',  # 9 = blood ketone
+    'id',
+    'month', 'day', 'year',  # year is two-digits
+    'hour', 'minute',
+    'unknown2',
+    'value',
+    'unknown3', 'unknown4',
 ))
+
+}
 
 
 class Device(freestyle.FreeStyleHidDevice):
@@ -57,24 +73,35 @@ class Device(freestyle.FreeStyleHidDevice):
             serial_number=self.get_serial_number(),
             version_info=(
                 'Software version: ' + self._get_version(),),
-            native_unit=self.get_glucose_unit())
+            native_unit=self.get_glucose_unit(),
+            ketone_unit=self.get_ketone_unit())
 
     def get_glucose_unit(self):
         """Returns the glucose unit of the device."""
         return common.UNIT_MGDL
 
+    def get_ketone_unit(self):
+        """Returns the ketones unit of the device."""
+        return common.UNIT_MMOLL
+
     def get_readings(self):
         """Iterate through the reading records in the device."""
         for record in self._get_multirecord(b'$result?'):
-            if not record or record[0] != _TYPE_GLUCOSE_READING:
+
+            try:
+                _TYPE_READING_NOW = record[0]
+            except IndexError:
+                _TYPE_READING_NOW = record
+            
+            if not _TYPE_READING_NOW in _TYPE_READING.values():
                 continue
 
             # Build a _reading object by parsing each of the entries in the CSV
             # as integers.
-            raw_reading = _NeoReading._make([int(v) for v in record])
+            raw_reading = _NeoReading[_TYPE_READING_NOW]._make([int(v) for v in record])
 
             timestamp = datetime.datetime(
                 raw_reading.year + 2000, raw_reading.month, raw_reading.day,
                 raw_reading.hour, raw_reading.minute)
 
-            yield common.Reading(timestamp, raw_reading.value)
+            yield common.Reading(timestamp, raw_reading.value, comment=list(_TYPE_READING.keys())[list(_TYPE_READING.values()).index(_TYPE_READING_NOW)])

--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -31,7 +31,7 @@ from glucometerutils.support import freestyle
 
 
 # The type is a string because it precedes the parsing of the object.
-_TYPE_READING = { 'Ketone' : '9' , 'Glucose' : '7' }
+_TYPE_READING = { 'ketone' : '9' , 'glucose' : '7' }
 
 _NeoReading = {
 
@@ -96,6 +96,13 @@ class Device(freestyle.FreeStyleHidDevice):
             if not _TYPE_READING_NOW in _TYPE_READING.values():
                 continue
 
+            typeofmeasure = list(_TYPE_READING.keys())[list(_TYPE_READING.values()).index(_TYPE_READING_NOW)]
+
+            if typeofmeasure is 'glucose':
+                unit = self.get_glucose_unit()
+            elif typeofmeasure is 'ketone':
+                unit = self.get_ketone_unit()
+
             # Build a _reading object by parsing each of the entries in the CSV
             # as integers.
             raw_reading = _NeoReading[_TYPE_READING_NOW]._make([int(v) for v in record])
@@ -104,4 +111,4 @@ class Device(freestyle.FreeStyleHidDevice):
                 raw_reading.year + 2000, raw_reading.month, raw_reading.day,
                 raw_reading.hour, raw_reading.minute)
 
-            yield common.Reading(timestamp, raw_reading.value, comment=list(_TYPE_READING.keys())[list(_TYPE_READING.values()).index(_TYPE_READING_NOW)])
+            yield common.Reading(timestamp, raw_reading.value, typeofmeasure=typeofmeasure, unit=unit)


### PR DESCRIPTION
- Support added to FreeStyle Precision Neo / FreeStyle Optium Neo. Deploy based on Optium, but can be extended if meter informs ketone and glucose units. If not, may be a command line support
- Added support to info command to display ketones and added the function to handle ketones.

Future commits may handle a non-ketone support (setting ketone_unit to NONE and handle it specially?)

Refers to https://github.com/Flameeyes/glucometerutils/issues/18 reported issue. Output from my Gluco:

```
 leonardo  ~  Development  Diabetes  glucometerutils  ./glucometer.py --driver fsprecisionneo info
FreeStyle Precision Neo
Serial Number: <OMMITED>
Version Information:
    Software version: 1.17 May 14 2014
Native Unit: mg/dL
Ketone Unit: mmol/L
Time: 2017-07-18 23:29:00
 leonardo  ~  Development  Diabetes  glucometerutils  ./glucometer.py --driver fsprecisionneo dump
"2017-07-18 14:36:00","1.00","","Ketone"
"2017-07-18 18:33:00","6.00","","Ketone"
```