### PR TITLE
Add support for the Bayer Contour USB glucose meter.

### DIFF
--- a/README
+++ b/README
@@ -46,6 +46,7 @@ supported.
 | Abbott       | FreeStyle Precision Neo | `fsprecisionneo`   | [construct] [hidapi]‡     |
 | Abbott       | FreeStyle Optium Neo    | `fsprecisionneo`   | [construct] [hidapi]‡     |
 | Abbott       | FreeStyle Optium Neo H  | `fsprecisionneo`   | [construct] [hidapi]‡     |
+| Bayer        | Contour USB             | `bacontour`        | [construct] [hidapi]‡     |
 | Roche        | Accu-Chek Mobile        | `accuchek_reports` |                           |
 | SD Biosensor | SD CodeFree             | `sdcodefree`       | [construct] [pyserial]    |
 

--- a/glucometerutils/drivers/bacontour.py
+++ b/glucometerutils/drivers/bacontour.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Driver for Bayer Countour USB
+"""
+
+from datetime import datetime
+
+from glucometerutils import common
+from glucometerutils.support import hiddevice, lis
+from glucometerutils.exceptions import InvalidResponse
+
+
+class BayerTLVMixin:
+    """
+    A mixin which should be used in conjunction with the LIS1aMixin
+    which implements the lowest layer protocol for the Bayer Contour USB devices
+    which is used on top of USB HID messages.
+    """
+    type_str = b'ABC'
+
+    def _write_lis1a_frame(self, data):
+        assert len(data) <= 60
+
+        data = self.type_str + chr(len(data)).encode('ascii') + data
+        pad_length = self.blocksize - len(data)
+        data += pad_length * b'\x00'
+
+        assert len(data) <= 64
+
+        self._write(data)
+
+    def _read_lis1a_frame(self):
+        """
+        This seems to be some home-made format.
+
+        it starts with the ASCII string 'ABC', after which follows
+        1 byte which contains the length of the data as a normal unsigned
+        integer, which should always be <= 60.
+        """
+        header_size = 4
+        data_length_offset = len(self.type_str)
+
+        block = b''
+        while True:
+            data = self._read()
+            if data is None:
+                break
+            if len(data) <= data_length_offset:
+                raise InvalidResponse(data)
+            data_length = data[data_length_offset]
+            start_byte = header_size
+            last_byte = start_byte + data_length
+            enc_data = data[start_byte:last_byte]
+            block += enc_data
+
+            #
+            # Note: when the data is _exactly_ 60 bytes, but
+            # is the last bit of data to be read, this won't
+            # break the loop, and will read() again, which will
+            # block the thread until timeout.
+            #
+            if len(enc_data) < self.blocksize - header_size:
+                break
+
+        return block
+
+
+class Device(BayerTLVMixin, lis.LIS2a2Mixin, hiddevice.HidDevice):
+    blocksize = 64
+    USB_VENDOR_ID = 0x1a79
+    USB_PRODUCT_ID = 0x6002
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._version_number = 'Unknown'
+        self._serial_number = 'Unknown'
+        self._glucose_unit = None
+        self._readings = []
+
+    def connect(self):
+        self.parse_lis2a2_messages()
+
+    def disconnect(self):
+        """Disconnect the device, nothing to be done."""
+        pass
+
+    def get_version(self):
+        return self._version_number
+
+    def get_serial_number(self):
+        return self._serial_number
+
+    def get_glucose_unit(self):
+        return self._glucose_unit or common.Unit.MMOL_L
+
+    def get_readings(self):
+        return self._readings
+
+    def get_meter_info(self):
+        return common.MeterInfo(
+            'Bayer Contour',
+            serial_number=self.get_serial_number(),
+            version_info=('Software version: ' + self.get_version(),),
+            native_unit=self.get_glucose_unit()
+        )
+
+    def get_datetime(self):
+        raise NotImplementedError
+
+    def set_datetime(self, date=None):
+        raise NotImplementedError
+
+    def zero_log(self):
+        raise NotImplementedError
+
+    def _process_lis2a2_header(self, header_fields):
+        """
+        These are the field types from the LIS2a2 standard for header records.
+        They don't exactly match with what I receive from my glucosemeter.
+        I'm not sure why that is.
+
+        6.1 Record Type ID
+        6.2 Delimiter Definition
+        6.3 Message Control ID
+        6.4 Access Password
+        6.5 Sender Name or ID
+        6.6 Sender Street Address
+        6.7 Reserved Field
+        6.8 Sender Telephone Number
+        6.9 Characteristics of Sender
+        6.10 Receiver ID
+        6.11 Comment or Special Instructions
+        6.12 Processing ID
+        6.13 Version Number
+        6.14 Date and Time of Message
+        """
+        # My machine returns '2408612' as the serial number, the protocol returns a field
+        # containing this: '7390-2408612', this is what i'm settings as the serial number.
+        self._serial_number = header_fields.get_component(2, 2, 1)
+
+        # My machine returns 'Versions: DE: 01.26, AE: 01.05, GP 08.02.20' as Versions,
+        # but i'm not sure what this means.
+        #
+        # The protocol returns the following fields, I'm including everything above,
+        # plus 'Bayer7390'
+        # [['Bayer7390', '01.26'], ['01.05'], ['08.02.20', '7390-2408612', '7397-']]
+
+        self._version_number = '{} DE: {} AE: {} GP: {}'.format(
+            header_fields.get_component(2, 0, 0),
+            header_fields.get_component(2, 0, 1),
+            header_fields.get_component(2, 1, 0),
+            header_fields.get_component(2, 2, 0),
+        )
+
+    def _process_lis2a2_result(self, result_fields):
+        """
+        These are the field types from the LIS2a2 standard for result records.
+        They don't exactly match with what I receive from my glucosemeter.
+        I'm not sure why that is.
+
+        9.1 Record Type ID
+        9.2 Sequence Number
+        9.3 Universal Test ID
+        9.4 Data or Measurement Value
+        9.5 LIS2-A2 Units
+        9.6 Reference Ranges
+        9.7 Result Abnormal Flags
+        9.8 Nature of Abnormality Testing
+        9.9 Result Status
+        9.10 Date of Change in Instrument Normative Values or Units
+        9.11 Operator Identification
+        9.12 Date/Time Test Started
+        9.13 Date/Time Test Completed
+        9.14 Instrument Identification
+        """
+
+        glucose_unit = result_fields.get_component(4)
+        assert glucose_unit in [unit.value for unit in common.Unit], \
+            'Expected the glucose unit: {} to be one of {}'.format(glucose_unit, ','.join(common.VALID_UNITS))
+        assert self._glucose_unit is None or self._glucose_unit == glucose_unit, \
+            'Only results from 1 glucose unit are allowed.'
+        self._glucose_unit = glucose_unit
+
+        glucose_level = common.convert_glucose_unit(
+            float(result_fields.get_component(3)),
+            self.get_glucose_unit(),
+            common.Unit.MG_DL
+        )
+        timestamp = datetime.strptime(result_fields.get_component(8).rstrip('\r'), "%Y%m%d%H%M")
+
+        self._readings.append(common.GlucoseReading(timestamp, glucose_level))

--- a/glucometerutils/support/lis.py
+++ b/glucometerutils/support/lis.py
@@ -1,0 +1,189 @@
+from glucometerutils.exceptions import InvalidResponse, InvalidChecksum
+
+ASCII_STX = b'\x02'
+ASCII_ETX = b'\x03'
+ASCII_EOT = b'\x04'
+ASCII_ENQ = b'\x05'
+ASCII_ACK = b'\x06'
+ASCII_ETB = b'\x17'
+ASCII_LF = b'\n'
+ASCII_CR = b'\r'
+
+
+class Fields:
+    def __init__(self, fields):
+        """
+        :param fields: a list of fields, a field is another list of repeat
+                       records, and a repeat record is another list of
+                       components.
+        """
+        self.fields = fields
+
+    @classmethod
+    def from_string(cls, delimiters, data):
+        """
+        :param delimiters: a dictionary with keys: 'component', 'repeat' and 'field' with
+                           as values the LIS2-a2 delimiter characters.
+        :param data:
+        """
+        fields = [[[component
+                    for component in repeat.split(delimiters['component'])]
+                   for repeat in field.split(delimiters['repeat'])]
+                  for field in data.split(delimiters['field'])]
+
+        return cls(fields)
+
+    def get_component(self, field, repeat=0, component=0):
+        try:
+            return self.fields[field][repeat][component].decode('latin1')
+        except IndexError:
+            raise InvalidResponse('Could not find field: {} repeat: {} component: {} in {}'.format(field, repeat, component, str(self.fields)))
+
+
+class LIS1aMixin:
+    def _write_lis1a_frame(self, data):
+        """
+        Write the LIS1a frame to the lower level protocol.
+        """
+        raise NotImplementedError
+
+    def _read_lis1a_frame(self):
+        """
+        Read the LIS1a frame from the lower level protocol. 
+        """
+        raise NotImplementedError
+
+    def _parse_lis1a_transfer_frame(self, previous_frame_number, data):
+        """
+        6.3 Process the LIS1A transfer frame.
+
+        <STX> FN text <ETB> C1 C2 <CR> <LF> (intermediate frame)
+        <STX> FN text <ETX> C1 C2 <CR> <LF> (end frame)
+        """
+
+        if data[:1] != ASCII_STX:
+            raise InvalidResponse(data)
+
+        try:
+            frame_number = int(data[1:2])
+        except ValueError:
+            raise InvalidResponse(data)
+
+        if frame_number > 7:
+            raise InvalidResponse(data)
+
+        if frame_number != (previous_frame_number + 1) % 8:
+            raise InvalidResponse(data)
+
+        if data[-5:-4] not in [ASCII_ETX, ASCII_ETB]:
+            raise InvalidResponse(data)
+        is_end_frame = data[-5:-4] == ASCII_ETX
+
+        # 6.3.3 - Checksum
+        try:
+            checksum = int(data[-4:-2], 16)
+        except ValueError:
+            raise InvalidResponse(data)
+        calculated_checksum = sum([c for c in data[1:-4]]) % 256
+        if calculated_checksum != checksum:
+            raise InvalidChecksum(calculated_checksum, checksum)
+
+        if data[-2:] != ASCII_CR + ASCII_LF:
+            raise InvalidResponse(data)
+
+        text = data[2:-5]
+
+        return frame_number, is_end_frame, text
+
+    def _parse_lis1a_transfer_frames(self, data):
+        previous_frame_number = 0
+        frames = []
+        while True:
+            data = self._read_lis1a_frame()
+            frame_number, is_end_frame, text = self._parse_lis1a_transfer_frame(previous_frame_number, data)
+            previous_frame_number = frame_number
+            frames.append(text)
+
+            # LIS1-A 6.3.4.2
+            self._write_lis1a_frame(ASCII_ACK)
+
+            if is_end_frame:
+                break
+
+        return frames
+
+
+class LIS2a2Mixin(LIS1aMixin):
+    def _parse_delimiters(self, data):
+        delimiters = data[1:5]
+        if len(delimiters) != 4:
+            raise InvalidResponse(data)
+        delimiters = {
+            'field': data[1:2],
+            'repeat': data[2:3],
+            'component': data[3:4],
+            'escape': data[4:5],
+        }
+        # Either this is the end of the record (no field delimiter needed)
+        # or is the end of the field.
+        if data[6:7] not in ['', delimiters['field']]:
+            raise InvalidResponse(data)
+        return delimiters
+
+    def _process_lis2a2_header(header_fields):
+        raise NotImplementedError
+
+    def _process_lis2a2_result(result_fields):
+        raise NotImplementedError
+
+    def _parse_lis2a2_message(self, frames):
+        # From the header record, the delimiters are determined.
+        header_frame = next(frames)
+        delimiters = self._parse_delimiters(header_frame)
+        header_fields = Fields.from_string(delimiters, header_frame[6:])
+
+        self._process_lis2a2_header(header_fields)
+
+        # TODO: Only support for 1 patient frame.
+        try:
+            patient_frame = next(frames)
+        except StopIteration:
+            # If no patient frame was found, do not bother to continue.
+            return
+
+        for result_frame in frames:
+            if result_frame[0:1] == b'L':
+                break
+            result_fields = Fields.from_string(delimiters, result_frame)
+            self._process_lis2a2_result(result_fields)
+
+    def parse_lis2a2_messages(self):
+        """
+        This is normally implemented as a FSM, which walks
+        through the various states, which can deal with error recovery.
+
+        I've simplified this a bit, and it now procedurally walks through
+        establishment phase, transfer phase and then termination phase. And
+        if an error occurs anywhere, it is fatal.
+        """
+
+        # Not sure if this first EOT is needed.
+#        self._write_lis1a_frame(ASCII_EOT)
+
+        data = self._read_lis1a_frame()
+        if data == ASCII_ENQ:
+            # LIS1-A 6.2.5
+            self._write_lis1a_frame(ASCII_ACK)
+        else:
+            raise InvalidResponse(data)
+
+        # LIS1-A 6.3 - Now we move to the transfer phase
+        frames = self._parse_lis1a_transfer_frames(data)
+
+        # Already start processing the LIS2-A2 message.
+        self._parse_lis2a2_message(iter(frames))
+
+        # LIS1-A 6.4 - Termination phase
+        data = self._read_lis1a_frame()
+        if data != ASCII_EOT:
+            raise InvalidResponse(data)

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -1,0 +1,30 @@
+from collections import namedtuple
+
+Operation = namedtuple('Operation', ['type', 'data'])
+
+
+class MockHandle(object):
+    def __init__(self, padding=None):
+        self.operations = iter([])
+        self.padding = padding or b''
+
+    def open(self, *args, **kwargs):
+        pass
+
+    def set_operations(self, operations):
+        self.operations = iter(operations)
+
+    def read(self, size):
+        operation = next(self.operations)
+        assert operation.type == 'read', operation.type
+        data = operation.data
+        data_len = len(data)
+        padding = self.padding * (size - data_len)
+        return data + padding
+
+    def write(self, data):
+        stripped_data = data.decode('latin1').rstrip('\x00').encode('latin1')
+        operation = next(self.operations)
+        assert operation.type == 'write'
+        assert operation.data == stripped_data, 'expected {} but received {}'.format(operation.data, data)
+        return len(data)

--- a/test/test_bacontour.py
+++ b/test/test_bacontour.py
@@ -1,0 +1,256 @@
+# -*- coding: utf-8 -*-
+
+
+"""Tests for the Bayer Contour driver."""
+
+__author__ = 'Alexander Schrijver'
+__email__ = 'alex@flupzor.nl'
+__copyright__ = 'Copyright © 2017, Alexander Schrijver'
+__license__ = 'MIT'
+
+
+import os
+import sys
+import unittest
+from datetime import datetime
+from unittest import mock
+from unittest.mock import MagicMock, Mock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from glucometerutils import exceptions, common
+from glucometerutils.drivers import bacontour
+
+from mocks import MockHandle, Operation
+
+
+class TestBayerContour(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(mock.patch.stopall)
+
+        self.handle_mock = MockHandle(padding=b'\x00')
+        self.hid_mock = MagicMock()
+        self.hid_mock.device.return_value = self.handle_mock
+        self.modules_mock = patch.dict('sys.modules', **{'hid': self.hid_mock, }).start()
+        self.device = bacontour.Device(None)
+
+    def test__get_lis1a_frame_too_small(self):
+        """
+        When the header is too small, an exception should be thrown.
+        """
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[b'123', None])
+        with self.assertRaises(exceptions.InvalidResponse):
+            self.device._read_lis1a_frame()
+
+    def test__get_lis1a_frame_one_block(self):
+        """
+        This is the normal case when a block is < 64 bytes.
+        """
+        data = b' ' * 40
+        frame = b'ABC' + chr(len(data)).encode('ascii') + data
+
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[frame, None])
+        read = self.device._read_lis1a_frame()
+        self.assertEqual(data, read)
+        self.device._read.assert_called_once()
+
+    def test__get_lis1a_frame_two_blocks(self):
+        """
+        Test the case where there are two blocks which should be read.
+        """
+        data1 = b' ' * 60
+        frame1 = b'ABC' + chr(len(data1)).encode('ascii') + data1
+        self.assertEqual(len(frame1), self.device.blocksize)
+
+        data2 = b' ' * 40
+        frame2 = b'ABC' + chr(len(data2)).encode('ascii') + data2
+
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[frame1, frame2, None])
+        read = self.device._read_lis1a_frame()
+        self.assertEqual(data1 + data2, read)
+        self.assertEqual(self.device._read.call_count, 2)
+
+    def test__read_lis1a_frame_exactly_two_blocks(self):
+        """
+        Test the case where there are two blocks of _exactly_ 64 bytes.
+        """
+        data1 = b' ' * 60
+        frame1 = b'ABC' + chr(len(data1)).encode('ascii') + data1
+        self.assertEqual(len(frame1), self.device.blocksize)
+
+        data2 = b' ' * 60
+        frame2 = b'ABC' + chr(len(data2)).encode('ascii') + data2
+
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[frame1, frame2, None])
+        read = self.device._read_lis1a_frame()
+        self.assertEqual(data1 + data2, read)
+        self.assertEqual(self.device._read.call_count, 3)
+
+    def test__read_lis1a_frame_nothing(self):
+        """
+        Test that when no data is read, the method still returns an
+        empty byte string.
+        """
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+        read = self.device._read_lis1a_frame()
+        self.assertEqual(read, b'')
+        self.device._read.assert_called_once()
+
+    def test__parse_lis1a_intermediate_transfer_frame(self):
+        """
+        Test parsing of a LIS1A intermediate frame.
+        """
+        test_frame = b'\x021SOMETEXT\x17C1\r\n'
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+        frame_number, is_end_frame, text = self.device._parse_lis1a_transfer_frame(0, test_frame)
+
+        self.assertEqual(frame_number, 1)
+        self.assertFalse(is_end_frame)
+        self.assertEqual(text, b'SOMETEXT')
+
+    def test__parse_lis1a_end_transfer_frame(self):
+        """
+        Test parsing of a LIS1A end frame.
+        """
+        test_frame = b'\x021SOMETEXT\x03AD\r\n'
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+        frame_number, is_end_frame, text = self.device._parse_lis1a_transfer_frame(0, test_frame)
+
+        self.assertEqual(frame_number, 1)
+        self.assertTrue(is_end_frame)
+        self.assertEqual(text, b'SOMETEXT')
+
+    def test__parse_lis1a_invalid_transfer_frame(self):
+        """
+        Test parsing of a LIS1A end frame with an invalid checksum.
+        """
+        test_frame = b'\x021SOMETEXT\x0300\r\n'
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+
+        with self.assertRaises(exceptions.InvalidChecksum) as e:
+            frame_number, is_end_frame, text = self.device._parse_lis1a_transfer_frame(0, test_frame)
+
+        self.assertEqual(
+            str(e.exception),
+            'Response checksum not matching: 000000ad expected, 00000000 gotten'
+        )
+
+    def test_lis2a2_header_record(self):
+        """
+        Test if the header record can be parsed properly.
+
+        I'm not entirely sure what all the data means, as reference i've used
+        the data that I found in the glucose meter itself.
+
+        Data from my Bayer Contour USB blood glucose meter
+
+        You can find the info by going to 'Setup' then 'Customer Service'
+        and then enter '3422' as access code.
+
+        Model: 7390
+        Serial 2408612
+        SKU: 7397
+
+        Versions: DE: 01.26, AE: 01.05, GP 08.02.20
+        """
+
+        frames = iter([
+            b'H|\\^&||abcdef|Bayer7390^01.26\\01.05\\08.02.20^7390-2408612^7397-|'
+            b'A=1^C=62^G=0^I=0200^R=0^S=1^U=1^V=10600^X=070070070070180130180250^'
+            b'Y=360126090050099050300089^Z=1|2000|||||P|1|201708242247',
+        ])
+
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+        self.device._parse_lis2a2_message(frames)
+
+        self.assertEqual(self.device.get_serial_number(), '7390-2408612')
+        self.assertEqual(self.device.get_version(), 'Bayer7390 DE: 01.26 AE: 01.05 GP: 08.02.20')
+
+    def test_lis2a2_result_records(self):
+        """
+        Test that result records can be properly processed.
+        """
+        frames = iter([
+            b'H|\^&||NIylNt|Bayer7390^01.26\\01.05\\08.02.20^7390-2408612^7397-|'
+            b'A=1^C=62^G=0^I=0200^R=0^S=1^U=1^V=10600^X=070070070070180130180250^'
+            b'Y=360126090050099050300089^Z=1|2000|||||P|1|201708290020',
+            b'P|1',
+            b'R|1|^^^Glucose|8.6|mmol/L^P||A||201608242306',
+            b'R|2|^^^Glucose|7.8|mmol/L^P||A||201608251230',
+            b'R|3|^^^Glucose|7.8|mmol/L^P||A||201608251833',
+            b'L|1||N',
+        ])
+
+        self.device._write = Mock(return_value=None)
+        self.device._read = Mock(side_effect=[None, None])
+        self.device._parse_lis2a2_message(frames)
+
+        readings = self.device.get_readings()
+        self.assertEqual(len(readings), 3)
+
+        # Due to rounding in unit conversion a bit of precision is lost.
+        self.assertEqual(readings[0].timestamp, datetime(2016, 8, 24, 23, 6))
+        self.assertAlmostEqual(readings[0].get_value_as(common.Unit.MMOL_L), 8.6, places=1)
+
+        self.assertEqual(readings[1].timestamp, datetime(2016, 8, 25, 12, 30))
+        self.assertAlmostEqual(readings[1].get_value_as(common.Unit.MMOL_L), 7.8, places=1)
+
+        self.assertEqual(readings[2].timestamp, datetime(2016, 8, 25, 18, 33))
+        self.assertAlmostEqual(readings[2].get_value_as(common.Unit.MMOL_L), 7.8, places=1)
+
+    def test_integration(self):
+        """
+        Except for the HID library (which is mocked) test the integration of all the components for
+        the bacontour driver.
+        """
+
+        operations = [
+            # ENQ
+            Operation('read', b"ABC\x01\x05"),
+            # ACK
+            Operation('write', b"ABC\x01\x06"),
+            # LIS2a2 headers
+            Operation('read', b'ABC<\x021H|\^&||NIylNt|Bayer7390^01.26\\01.05\\08.02.20^7390-2408612^'),
+            Operation('read', b'ABC<7397-|A=1^C=62^G=0^I=0200^R=0^S=1^U=1^V=10600^X=070070070070'),
+            Operation('read', b'ABC<180130180250^Y=360126090050099050300089^Z=1|2000|||||P|1|201'),
+            Operation('read', b'ABC\x0f708222058\r\x17AB\r\n'),
+            # LIS2a2 headers ack
+            Operation('write', b'ABC\x01\x06'),
+            # LIS2a2 patient record
+            Operation('read', b'ABC\x0b\x022P|1\r\x1753\r\n'),
+            # ACK
+            Operation('write', b'ABC\x01\x06'),
+            # LIS2a2 results
+            Operation('read', b'ABC5\x023R|1|^^^Glucose|10.9|mmol/L^P||A||201504171154\r\x17EC\r\n'),
+            Operation('write', b'ABC\x01\x06'),
+            Operation('read', b'ABC\x0e\x024L|1||N\r\x0383\r\n'),
+            Operation('write', b'ABC\x01\x06'),
+            Operation('read', b'ABC\x01\x04'),
+        ]
+        self.handle_mock.set_operations(operations)
+
+        self.device.connect()
+
+        readings = self.device.get_readings()
+        self.assertEqual(len(readings), 1)
+
+        self.assertEqual(self.device.get_serial_number(), '7390-2408612')
+        self.assertEqual(self.device.get_version(), 'Bayer7390 DE: 01.26 AE: 01.05 GP: 08.02.20')
+
+        # Due to rounding in unit conversion a bit of precision is lost.
+        self.assertEqual(readings[0].timestamp, datetime(2015, 4, 17, 11, 54))
+        self.assertAlmostEqual(readings[0].get_value_as(common.Unit.MMOL_L), 10.9, places=1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This implements the CLSI LIS1a and LIS2a2 protocols as mixins, which can be used with HIDDevice or SerialDevice to create a device capable of communicating using one of these protocols.

The Bayer Contour USB driver utilizes the LIS1a and LIS2a2 mixins together with a custom TLV-type protocol (probably created by Bayer) to retrieve the glucose results over USB Hid messages. Serial communication has not been implemented yet.

Note that I tried creating a driver for the Bayer Contour TS as well, which uses a 3.5mm TRS cable for serial communication using TTL-logic level with baudrate of 9600. For some reason the only data I can get back was something like 0x06, or 0x05 (I can't remember what it was exactly) when I wrote either 0x05 or 0x06. Note that I didn't use the official cable, since it is impossible to get one in the Netherlands (Altough I doubt that's the problem).