### PR TITLE
Construct uptodate fixes

### DIFF
--- a/glucometerutils/drivers/otultraeasy.py
+++ b/glucometerutils/drivers/otultraeasy.py
@@ -116,7 +116,7 @@ class Device(serial.SerialDevice):
 
     def _send_packet(self, message, acknowledge=False, disconnect=False):
         pkt = _PACKET.build(
-            {'value': {
+            {'data': {'value': {
                 'message': message,
                 'link_control': {
                     'sequence_number': self.sent_counter_,
@@ -124,14 +124,14 @@ class Device(serial.SerialDevice):
                     'acknowledge': acknowledge,
                     'disconnect': disconnect,
                 },
-            }})
+            }}})
         logging.debug('sending packet: %s', binascii.hexlify(pkt))
 
         self.serial_.write(pkt)
         self.serial_.flush()
 
     def _read_packet(self):
-        raw_pkt = self.buffered_reader_.parse_stream(self.serial_)
+        raw_pkt = self.buffered_reader_.parse_stream(self.serial_).data
         logging.debug('received packet: %r', raw_pkt)
 
         # discard the checksum and copy

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -53,8 +53,7 @@ _QUERY_REQUEST = construct.Struct(
 
 _QUERY_RESPONSE = construct.Struct(
     lifescan_binary_protocol.COMMAND_SUCCESS,
-    # This should be an UTF-16L CString, but construct does not support it.
-    'value' / construct.GreedyString(encoding='utf-16-le'),
+    'value' / construct.CString(encoding='utf-16-le'),
 )
 
 _READ_PARAMETER_REQUEST = construct.Struct(

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -42,8 +42,8 @@ from glucometerutils.support import lifescan_binary_protocol
 _REGISTER_SIZE = 512
 
 _PACKET = construct.Padded(
-    _REGISTER_SIZE, construct.Embedded(
-        lifescan_binary_protocol.LifeScanPacket(0x03, False)))
+    _REGISTER_SIZE,
+        lifescan_binary_protocol.LifeScanPacket(0x03, False))
 
 _QUERY_REQUEST = construct.Struct(
     construct.Const(b'\xe6\x02'),
@@ -157,9 +157,9 @@ class Device(object):
         """
         try:
             request = request_format.build(request_obj)
-            request_raw = _PACKET.build({'value': {
+            request_raw = _PACKET.build({'data': {'value': {
                 'message': request,
-            }})
+            }}})
             logging.debug(
                 'Request sent: %s', binascii.hexlify(request_raw))
             self.scsi_.write10(lba, 1, request_raw)
@@ -167,7 +167,7 @@ class Device(object):
             response_raw = self.scsi_.read10(lba, 1)
             logging.debug(
                 'Response received: %s', binascii.hexlify(response_raw.datain))
-            response_pkt = _PACKET.parse(response_raw.datain)
+            response_pkt = _PACKET.parse(response_raw.datain).data
             logging.debug('Response packet: %r', response_pkt)
 
             response = response_format.parse(response_pkt.value.message)

--- a/glucometerutils/drivers/otverio2015.py
+++ b/glucometerutils/drivers/otverio2015.py
@@ -108,7 +108,7 @@ _READ_RECORD_RESPONSE = construct.Struct(
     'lifetime_counter' / construct.Int16ul,
     'timestamp' / lifescan_binary_protocol.VERIO_TIMESTAMP,
     'value' / construct.Int16ul,
-    'meal' / construct.SymmetricMapping(
+    'meal' / construct.Mapping(
         construct.Byte, _MEAL_FLAG),
     construct.Padding(4),
 )

--- a/glucometerutils/drivers/otverioiq.py
+++ b/glucometerutils/drivers/otverioiq.py
@@ -120,16 +120,16 @@ class Device(serial.SerialDevice):
 
     def _send_packet(self, message):
         pkt = _PACKET.build(
-            {'value': {
+            {'data': {'value': {
                 'message': message,
-            }})
+            }}})
         logging.debug('sending packet: %s', binascii.hexlify(pkt))
 
         self.serial_.write(pkt)
         self.serial_.flush()
 
     def _read_packet(self):
-        raw_pkt = self.buffered_reader_.parse_stream(self.serial_)
+        raw_pkt = self.buffered_reader_.parse_stream(self.serial_).data
         logging.debug('received packet: %r', raw_pkt)
 
         # discard the checksum and copy

--- a/glucometerutils/drivers/otverioiq.py
+++ b/glucometerutils/drivers/otverioiq.py
@@ -97,7 +97,7 @@ _READING_RESPONSE = construct.Struct(
     'timestamp' / lifescan_binary_protocol.VERIO_TIMESTAMP,
     'value' / construct.Int16ul,
     'control_test' / construct.Flag,
-    'meal' / construct.SymmetricMapping(
+    'meal' / construct.Mapping(
         construct.Byte, _MEAL_FLAG),
     construct.Padding(2),  # unknown
 )

--- a/glucometerutils/drivers/sdcodefree.py
+++ b/glucometerutils/drivers/sdcodefree.py
@@ -45,8 +45,8 @@ _PACKET = construct.Struct(
         construct.Byte,
         {e: e.value for e in Direction}),
     'length' / construct.Rebuild(
-        construct.Byte, lambda ctx: len(ctx.message) + 2),
-    'message' / construct.Bytes(length=lambda ctx: ctx.length - 2),
+        construct.Byte, lambda this: len(this.message) + 2),
+    'message' / construct.Bytes(lambda this: len(this.message)),
     'checksum' / construct.Checksum(
         construct.Byte, xor_checksum, construct.this.message),
     'etx' / construct.Const(0xAA, construct.Byte)

--- a/glucometerutils/drivers/sdcodefree.py
+++ b/glucometerutils/drivers/sdcodefree.py
@@ -40,7 +40,7 @@ class Direction(enum.Enum):
     Out = 0x10
 
 _PACKET = construct.Struct(
-    'stx' / construct.Const(construct.Byte, 0x53),
+    'stx' / construct.Const(0x53, construct.Byte),
     'direction' / construct.SymmetricMapping(
         construct.Byte,
         {e: e.value for e in Direction}),
@@ -49,13 +49,14 @@ _PACKET = construct.Struct(
     'message' / construct.Bytes(length=lambda ctx: ctx.length - 2),
     'checksum' / construct.Checksum(
         construct.Byte, xor_checksum, construct.this.message),
-    'etx' / construct.Const(construct.Byte, 0xAA)
+    'etx' / construct.Const(0xAA, construct.Byte)
 )
 
 _FIRST_MESSAGE = construct.Struct(
-    construct.Const(construct.Byte, 0x30),
+    construct.Const(0x30, construct.Byte),
     'count' / construct.Int16ub,
-    construct.Const(construct.Byte, 0xAA)[19])
+    construct.Const(0xAA, construct.Byte)[19],
+)
 
 _CHALLENGE_PACKET_FULL = b'\x53\x20\x04\x10\x30\x20\xAA'
 _RESPONSE_MESSAGE = b'\x10\x40'

--- a/glucometerutils/drivers/sdcodefree.py
+++ b/glucometerutils/drivers/sdcodefree.py
@@ -41,7 +41,7 @@ class Direction(enum.Enum):
 
 _PACKET = construct.Struct(
     'stx' / construct.Const(0x53, construct.Byte),
-    'direction' / construct.SymmetricMapping(
+    'direction' / construct.Mapping(
         construct.Byte,
         {e: e.value for e in Direction}),
     'length' / construct.Rebuild(
@@ -82,7 +82,7 @@ _READING = construct.Struct(
     'hour' / construct.Byte,
     'minute' / construct.Byte,
     'value' / construct.Int16ub,
-    'meal' / construct.SymmetricMapping(
+    'meal' / construct.Mapping(
         construct.Byte, _MEAL_FLAG),
     construct.Byte[7],
 )

--- a/glucometerutils/support/construct_extras.py
+++ b/glucometerutils/support/construct_extras.py
@@ -23,11 +23,11 @@ class Timestamp(construct.Adapter):
         super(Timestamp, self).__init__(subcon)
         self.epoch = epoch
 
-    def _encode(self, obj, context):
+    def _encode(self, obj, context, path):
         assert isinstance(obj, datetime.datetime)
         epoch_date = datetime.datetime.utcfromtimestamp(self.epoch)
         delta = obj - epoch_date
         return int(delta.total_seconds())
 
-    def _decode(self, obj, context):
+    def _decode(self, obj, context, path):
         return datetime.datetime.utcfromtimestamp(obj + self.epoch)

--- a/glucometerutils/support/freestyle.py
+++ b/glucometerutils/support/freestyle.py
@@ -26,7 +26,7 @@ from glucometerutils.support import hiddevice
 _INIT_SEQUENCE = (0x04, 0x05, 0x15, 0x01)
 
 _FREESTYLE_MESSAGE = construct.Struct(
-    'hid_report' / construct.Const(construct.Byte, 0),
+    'hid_report' / construct.Const(0, construct.Byte),
     'message_type' / construct.Byte,
     'command' / construct.Padded(
         63,  # command can only be up to 62 bytes, but one is used for length.

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -55,7 +55,7 @@ def LifeScanPacket(command_prefix, include_link_control):
 COMMAND_SUCCESS = construct.Const(b'\x06')
 
 VERIO_TIMESTAMP = construct_extras.Timestamp(
-    construct.Int32ul, epoch=946684800)  # 2010-01-01 00:00
+    construct.Int32ul, epoch=946684800)  # 2000-01-01 (not 2010)
 
 _GLUCOSE_UNIT_MAPPING_TABLE = {
     common.Unit.MG_DL: 0x00,

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -40,11 +40,11 @@ def LifeScanPacket(command_prefix, include_link_control):
                 construct.Struct(
                     construct.Const(b'\x02'),  # stx
                     'length' / construct.Rebuild(
-                        construct.Byte, lambda ctx: len(ctx.message) + 7),
+                        construct.Byte, lambda this: len(this.message) + 7),
                     'link_control' / link_control_construct,
                     'command_prefix' / command_prefix_construct,
                     'message' / construct.Bytes(
-                        length=lambda ctx: ctx.length - 7),
+                        lambda this: len(this.message)),
                     construct.Const(b'\x03'),  # etx
                 ),
         ),

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -33,7 +33,7 @@ def LifeScanPacket(command_prefix, include_link_control):
     else:
         link_control_construct = construct.Const(b'\x00')
 
-    command_prefix_construct = construct.Const(construct.Byte, command_prefix)
+    command_prefix_construct = construct.Const(command_prefix, construct.Byte)
 
     return construct.Struct(
         construct.RawCopy(

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -62,5 +62,5 @@ _GLUCOSE_UNIT_MAPPING_TABLE = {
     common.Unit.MMOL_L: 0x01,
 }
 
-GLUCOSE_UNIT = construct.SymmetricMapping(
+GLUCOSE_UNIT = construct.Mapping(
     construct.Byte, _GLUCOSE_UNIT_MAPPING_TABLE)

--- a/glucometerutils/support/lifescan_binary_protocol.py
+++ b/glucometerutils/support/lifescan_binary_protocol.py
@@ -36,8 +36,7 @@ def LifeScanPacket(command_prefix, include_link_control):
     command_prefix_construct = construct.Const(command_prefix, construct.Byte)
 
     return construct.Struct(
-        construct.RawCopy(
-            construct.Embedded(
+        'data' / construct.RawCopy(
                 construct.Struct(
                     construct.Const(b'\x02'),  # stx
                     'length' / construct.Rebuild(
@@ -48,10 +47,9 @@ def LifeScanPacket(command_prefix, include_link_control):
                         length=lambda ctx: ctx.length - 7),
                     construct.Const(b'\x03'),  # etx
                 ),
-            ),
         ),
         'checksum' / construct.Checksum(
-            construct.Int16ul, lifescan.crc_ccitt, construct.this.data),
+            construct.Int16ul, lifescan.crc_ccitt, construct.this.data.data),
     )
 
 COMMAND_SUCCESS = construct.Const(b'\x06')

--- a/setup.py
+++ b/setup.py
@@ -49,15 +49,15 @@ setup(
         # These are all the drivers' dependencies. Optional dependencies are
         # listed as mandatory for the feature.
         'otultra2': ['pyserial'],
-        'otultraeasy': ['construct==2.8.22', 'pyserial'],
-        'otverio2015': ['construct==2.8.22', 'python-scsi'],
-        'otverioiq': ['construct==2.8.22', 'pyserial'],
-        'fsinsulinx': ['construct==2.8.22', 'hidapi'],
-        'fslibre': ['construct==2.8.22', 'hidapi'],
+        'otultraeasy': ['construct', 'pyserial'],
+        'otverio2015': ['construct', 'python-scsi'],
+        'otverioiq': ['construct', 'pyserial'],
+        'fsinsulinx': ['construct', 'hidapi'],
+        'fslibre': ['construct', 'hidapi'],
         'fsoptium': ['pyserial'],
-        'fsprecisionneo': ['construct==2.8.22', 'hidapi'],
+        'fsprecisionneo': ['construct', 'hidapi'],
         'accucheck_reports': [],
-        'sdcodefree': ['construct==2.8.22', 'pyserial'],
+        'sdcodefree': ['construct', 'pyserial'],
     },
     entry_points = {
         'console_scripts': [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 absl-py
-construct==2.8.22
+construct
 pytest
 pytest-timeout
 pyserial


### PR DESCRIPTION
For the record, I am the developer of Construct. This fixes all present day issues related to it. Unfortunately the test suite does not really cover parsing (aside of one custom adapter, Timestamp) so you need some handson testing.

I would recommend dropping SymmetricMapping and using Enum instead, especiall that now it supports both enum34 merging and exposing labels as attributes. See docs:
https://construct.readthedocs.io/en/latest/api/mappings.html#construct.Enum
