### PR TITLE
Fix for non-integer errors

### DIFF
--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -84,7 +84,7 @@ class Device(freestyle.FreeStyleHidDevice):
             values = []
             for v in record:
                 if v == "HI":
-                    v = 999
+                    v = float("inf")
                 values.append(int(v))
             raw_reading = _NeoReading._make(values[:len(_NeoReading._fields)])
 

--- a/glucometerutils/drivers/fsprecisionneo.py
+++ b/glucometerutils/drivers/fsprecisionneo.py
@@ -81,7 +81,11 @@ class Device(freestyle.FreeStyleHidDevice):
 
             # Build a _reading object by parsing each of the entries in the raw
             # record
-            values = [int(v) for v in record]
+            values = []
+            for v in record:
+                if v == "HI":
+                    v = 999
+                values.append(int(v))
             raw_reading = _NeoReading._make(values[:len(_NeoReading._fields)])
 
             timestamp = datetime.datetime(


### PR DESCRIPTION
This is a quick fix I used to address an error for "HI" readings on my unit.  This comes up when testing inhuman blood.  There may be a "LO", but I have not encountered it, so I do not know how the specifics of it.  This error may come up on other units, but I have just done something about the hardware I have access to.